### PR TITLE
Add -version flag with build-time version injection

### DIFF
--- a/.version.sh
+++ b/.version.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "$(git tag --points-at HEAD)" ]; then
+	git describe --always --long --dirty | sed 's/^v//'
+else
+	git tag --points-at HEAD | sed 's/^v//' | awk '{ print length, $0 }' | sort -n -s | cut -d" " -f2- | tail -n 1
+fi

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 SHELL:=/usr/bin/env bash
 
+BIN_NAME:=hosts-timer
+BIN_VERSION:=$(shell ./.version.sh)
+
 default: help
 
 # via https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
@@ -14,8 +17,8 @@ clean: ## Remove built products in ./out
 .PHONY: build
 build: clean ## Build (for the current platform & architecture) to ./out
 	mkdir -p out
-	go build -o ./out/hosts-timer .
+	go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME} .
 
 .PHONY: install
 install: ## Build & install hosts-timer to /usr/local/bin
-	go build -o /usr/local/bin/hosts-timer .
+	go build -ldflags="-X main.version=${BIN_VERSION}" -o /usr/local/bin/${BIN_NAME} .

--- a/main.go
+++ b/main.go
@@ -13,6 +13,8 @@ import (
 	"github.com/txn2/txeh"
 )
 
+var version = "<dev>"
+
 const (
 	usageExit = 1
 	hostsErrExit = 2
@@ -38,8 +40,14 @@ func main() {
 	flag_time := flag.String("time", "", "Enable access to the domain(s) for the given amount of time " +
 		"(string like 1h5m30s). Access is disabled after that time, or when the process receives SIGINT/SIGTERM " +
 		"(eg. Ctrl-C). Cannot be used with -enable or -disable.")
+	flag_version := flag.Bool("version", false, "Print version and exit.")
 	flag.Usage = usage
 	flag.Parse()
+
+	if *flag_version {
+		fmt.Printf("hosts-timer %s\n", version)
+		os.Exit(0)
+	}
 
 	var domains []string
 	for _, d := range flag.Args() {


### PR DESCRIPTION
## Summary

Resolves #5. Adds build-time version injection following the same pattern used in [lychee-ai-organizer](https://github.com/cdzombak/lychee-ai-organizer):

- **`main.go`**: Adds a `version` variable (defaulting to `<dev>`) and a `-version` flag that prints it and exits.
- **`Makefile`**: Injects the version string via `-ldflags="-X main.version=..."` in both `build` and `install` targets. Introduces `BIN_NAME` and `BIN_VERSION` variables.
- **`.version.sh`**: New script (copied from lychee-ai-organizer) that derives the version string from git tags or `git describe`.

## Review & Testing Checklist for Human

- [ ] Run `make build && ./out/hosts-timer -version` — verify it prints a version string (e.g. `hosts-timer <hash>-dirty` or a tag-based version)
- [ ] Verify `hosts-timer -version` works without `sudo` and without any domain arguments
- [ ] Tag a test commit and confirm `.version.sh` outputs the clean tag version

### Notes

- A pre-existing `go vet` warning (`misuse of unbuffered os.Signal channel`) exists on `main` and is unrelated to this PR.

Link to Devin session: https://app.devin.ai/sessions/5e030197e2ce44c99c7b7766fa2404c4
Requested by: @cdzombak

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-version` command-line flag to display the application version.

* **Chores**
  * Updated build process to dynamically embed version information into the compiled binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->